### PR TITLE
chore: update the node version used in CI to 16

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: '16.x'
       - name: Install
         run: yarn install --frozen-lockfile
       - name: Lint commits

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: '16.x'
       - name: Install
         run: yarn install --frozen-lockfile
       - name: Test
@@ -29,7 +29,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: '16.x'
       - name: Install
         run: yarn install --frozen-lockfile
       - name: Test


### PR DESCRIPTION
Maybe this will help with some CI errors in the PR for updating color.js